### PR TITLE
Updates external data source to get argocd config

### DIFF
--- a/scripts/argocd-webhook.sh
+++ b/scripts/argocd-webhook.sh
@@ -3,6 +3,11 @@
 ARGOCD_HOST="$1"
 GIT_URL="$2"
 
+if [[ -z "${ARGOCD_HOST}" ]] || [[ -z "${GIT_URL}" ]]; then
+  echo "usage: argocd-webhook.sh ARGOCD_HOST GIT_URL"
+  exit 1
+fi
+
 if [[ -z "${GIT_TOKEN}" ]]; then
   echo "GIT_TOKEN must be provided as an environment variable"
   exit 1

--- a/scripts/get-argocd-config.sh
+++ b/scripts/get-argocd-config.sh
@@ -22,16 +22,16 @@ if ! command -v jq 1> /dev/null 2> /dev/null; then
 fi
 
 if ! oc get route "${ROUTE_NAME}" -n "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
-  echo "{\"status\": \"error\", \"message\": \"Unable to find route: ${NAMESPACE}/${ROUTE_NAME}\"}"
-  exit 1
+  echo "{\"host\": \"\", \"user\": \"\", \"password\":\"\", \"status\": \"error\", \"message\": \"Unable to find route: ${NAMESPACE}/${ROUTE_NAME}\"}"
+  exit 0
 fi
 
 HOST=$(oc get route "${ROUTE_NAME}" -n "${NAMESPACE}" -o json | jq -r '.spec.host')
 USER="admin"
 
 if ! oc get secret "${SECRET_NAME}" -n "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
-  echo "{\"status\": \"error\", \"message\": \"Unable to find secret: ${NAMESPACE}/${SECRET_NAME}\"}"
-  exit 1
+  echo "{\"host\": \"\", \"user\": \"\", \"password\":\"\", \"status\": \"error\", \"message\": \"Unable to find secret: ${NAMESPACE}/${SECRET_NAME}\"}"
+  exit 0
 fi
 
 PASSWORD=$(oc get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["admin.password"]')


### PR DESCRIPTION
Updates get-argocd-config.sh to return a json object with an error status and empty host, username, and password values instead of a non-zero return code when there is a problem getting information about ArgoCD. Downstream resources will throw an error if the host, username, and password are missing.

Closes #16
