### PR TITLE
Enables create_tls_secret resource to log to console

### DIFF
--- a/.github/workflows/notify-local.yaml
+++ b/.github/workflows/notify-local.yaml
@@ -1,0 +1,23 @@
+name: Notify dependencies
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        repo:
+          - cloud-native-toolkit/terraform-tools-argocd-bootstrap
+
+    steps:
+      - name: Repository dispatch ${{ matrix.repo }}
+        uses: cloud-native-toolkit/action-repository-dispatch@main
+        with:
+          notifyRepo: ${{ matrix.repo }}
+          eventType: released
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource null_resource create_tls_secret {
     environment = {
       BIN_DIR     = self.triggers.bin_dir
       KUBECONFIG  = self.triggers.kubeconfig
-      PRIVATE_KEY = var.sealed_secret_private_key
+      PRIVATE_KEY = nonsensitive(var.sealed_secret_private_key)
       CERT        = var.sealed_secret_cert
       TMP_DIR     = local.tmp_dir
     }


### PR DESCRIPTION
- Sets sealed_secret_private_key tp nonsensitive in resource to allow logs to show - closes #24
- Notifies argocd-bootstrap when a new release is published

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>